### PR TITLE
fix ambiguous import

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ mod valid;
 use num_traits::{NumAssignOps, PrimInt};
 
 use aat::aat;
-pub use amd::*;
+pub use crate::amd::*;
 use amd_1::amd_1;
 pub use control::control;
 pub use info::info;


### PR DESCRIPTION
`cargo test` fails with this error:
```rust 
error[E0659]: `amd` is ambiguous
  --> ..../amd/src/lib.rs:22:9
   |
22 | pub use amd::*;
   |         ^^^ ambiguous name
   |
   = note: ambiguous because of multiple potential import sources
   = note: `amd` could refer to a crate passed with `--extern`
   = help: use `::amd` to refer to this crate unambiguously
note: `amd` could also refer to the module defined here
  --> ..../amd/src/lib.rs:7:1
   |
7  | mod amd;
   | ^^^^^^^^
   = help: use `crate::amd` to refer to this module unambiguously
```
PR just adds the crate annotation at the suggestion of the compiler, which seems to fix the problem.