### PR TITLE
Removes redundant allocations in postorder

### DIFF
--- a/src/post_tree.rs
+++ b/src/post_tree.rs
@@ -6,9 +6,9 @@ pub fn post_tree(
     child: &mut [isize], // input of size nn, undefined on output
     sibling: &[isize],   // input of size nn, not modified
     order: &mut [isize], // output of size nn
+    stack: &mut [isize],
     nn: usize,
 ) -> usize {
-    let mut stack: Vec<isize> = vec![0; nn];
 
     /*if false {
         // Recursive version (stack[] is not used):

--- a/src/postorder.rs
+++ b/src/postorder.rs
@@ -168,11 +168,11 @@ the biggest child last in each list:"
     }
 
     let mut k = 0;
+    let mut stack: Vec<isize> = vec![0; nn];
     for i in 0..nn {
         if parent[i] == EMPTY && nv[i] > 0 {
             debug1_print!("Root of assembly tree {}\n", i);
-            // k = post_tree(i, k, &mut child, sibling, &mut order, &mut stack, nn);
-            k = post_tree(i, k, &mut child, &sibling, &mut order, nn);
+            k = post_tree(i, k, &mut child, &sibling, &mut order, &mut stack, nn);
         }
     }
 


### PR DESCRIPTION
Brings an allocation of the `stack` vector outside of `post_tree` and into the enclosing loop in `postorder`.   This provides a significant improvement in execution times for large matrices.

Note that I think it is also not a requirement that the stack be cleared or otherwise reinitialised between calls, so I have not done so for the sake of efficiency.