### PR TITLE
Subtraction overflow error fix

### DIFF
--- a/src/amd_2.rs
+++ b/src/amd_2.rs
@@ -379,7 +379,7 @@ pub fn amd_2<I: PrimInt + Display>(
                                     pdst += 1;
                                     let lenj = len[j as usize];
                                     // Copy from source to destination.
-                                    for _knt3 in 0..=lenj - 2 {
+                                    for _knt3 in 0..=(lenj as isize) - 2 {
                                         iw[pdst] = iw[psrc];
                                         pdst += 1;
                                         psrc += 1;


### PR DESCRIPTION
Fixes #3.   I have checked the behaviour in the example against the original version with maximum debug verbosity enabled.  The results are identical.  It seems that the intention really is to let the upper limit of the counter at line 382 noted in #3 to become negative, but Rust does not like the silent cast to an unsigned value.   An explicit cast to `isize` prior to subtracting fixes it.